### PR TITLE
Update .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ Bundler/OrderedGems:
   Exclude:
     - Gemfile
 Metrics/LineLength:
-  Max: 150
+  Max: 160
 Naming/FileName:
   Exclude:
     - Gemfile


### PR DESCRIPTION
# WHAT
rubocopの設定を変更。
１行160文字までOKにしました。